### PR TITLE
Fix activity leak by using class instead of object

### DIFF
--- a/app/src/main/java/de/stroeer/locatorandroid/MainActivity.kt
+++ b/app/src/main/java/de/stroeer/locatorandroid/MainActivity.kt
@@ -22,7 +22,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun startLocationDiscoveryProcess() {
         val permissionRationale = getLocationPermissionRationale()
-        Locator.getCurrentLocation(this, permissionRationale) { locationEvent ->
+        Locator(this).getCurrentLocation(permissionRationale) { locationEvent ->
             when (locationEvent) {
                 is Event.Location -> handleLocationEvent(locationEvent)
                 is Event.Permission -> handlePermissionEvent(locationEvent)

--- a/locator-android/src/main/java/de/stroeer/locator_android/LocationProvider.kt
+++ b/locator-android/src/main/java/de/stroeer/locator_android/LocationProvider.kt
@@ -5,6 +5,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import com.example.tomo_location.Logger
+import java.lang.Exception
 import com.google.android.gms.location.FusedLocationProviderClient as GoogleFLPC
 import com.google.android.gms.location.LocationServices as GoogleLocationServices
 import com.huawei.hms.location.FusedLocationProviderClient as HuaweiFLPC
@@ -57,13 +58,9 @@ class LocationProvider(
         }
     }
 
-    // TODO should we call it externally?
-    fun stopService() {
-        // unregister receiver if it's registered
-        val intentForQuery = LocationPermissionBroadcastReceiver.getIntentForQuery()
-        val resolveInfo = activity.packageManager.queryBroadcastReceivers(intentForQuery, 0)
-        if (resolveInfo.isNotEmpty()) {
-            activity.unregisterReceiver(locationPermissionBroadcastReceiver)
+    private fun stopService() {
+        try { activity.unregisterReceiver(locationPermissionBroadcastReceiver) } catch (e: Exception) {
+            Logger.logDebug("Failed to unregister broadcast receiver")
         }
 
         // stop searching
@@ -74,7 +71,7 @@ class LocationProvider(
     }
 
     fun startLocationDiscoveryOrStartPermissionResolution() {
-        activity.application.registerReceiver(locationPermissionBroadcastReceiver, filter)
+        activity.registerReceiver(locationPermissionBroadcastReceiver, filter)
         startPermissionAndResolutionProcess(activity)
     }
 

--- a/locator-android/src/main/java/de/stroeer/locator_android/Locator.kt
+++ b/locator-android/src/main/java/de/stroeer/locator_android/Locator.kt
@@ -17,12 +17,11 @@ enum class EventType {
     LOCATION_DISABLED_ON_DEVICE
 }
 
-object Locator {
+class Locator(val activity: AppCompatActivity) {
 
     private lateinit var locationProvider: LocationProvider
 
-    fun getCurrentLocation(activity: AppCompatActivity,
-                           rationale: LocationPermissionRationaleMessage? = null,
+    fun getCurrentLocation(rationale: LocationPermissionRationaleMessage? = null,
                            eventCallback: (Event) -> Unit
     ) {
         initLocationProvider(activity, eventCallback, rationale)
@@ -33,7 +32,7 @@ object Locator {
                                      eventCallback: (Event) -> Unit,
                                      locationPermissionRationaleMessage: LocationPermissionRationaleMessage?
     ) {
-        if (!Locator::locationProvider.isInitialized) {
+        if (!::locationProvider.isInitialized) {
             val locationProviderType = if (isGooglePlayServicesAvailable(activity)) LocationDelegate.GOOGLE else LocationDelegate.HUAWEI
             locationProvider = LocationProvider(activity, eventCallback, locationProviderType, locationPermissionRationaleMessage)
         }


### PR DESCRIPTION
Reproduction steps: 
- user opens activity and fetches location;
- user closes activity and reopens it again;
- on the next try to fetch location user doesn't see any changes in UI, since callback gets triggered in the first (leaked) activity. When used with coroutines "Job was cancelled"-error to be seen in Logcat.